### PR TITLE
Added DHCP Snooping and ARP Inspection deploy options.

### DIFF
--- a/tests/IntStatusParseTest.py
+++ b/tests/IntStatusParseTest.py
@@ -742,7 +742,7 @@ for line in int_output:
     # Split line by spaces.
     line = re.split(" +", line)
     # Check if the second to last element contains just CSR4. If so, then join the last two elements together.
-    if line[-2] == "CSR4":
+    if "SR4" in line[-2]:
       # Get the last two elements and add them together.
         new_type = f"{line.pop(-4)} {line.pop(-3)} {line.pop(-2)} {line.pop(-1)}"
         # Reappend to line.
@@ -888,3 +888,4 @@ for interface in interfaces:
             interface["switchport voice vlan"] = switch_voice_vlan
             interface["switchport trunk native vlan"] = switch_trunk_vlan
             interface["config_has_changed"] = False
+            print(interface)

--- a/utils/deploy_options.py
+++ b/utils/deploy_options.py
@@ -25,6 +25,7 @@ def find_ranges(iterable):
 def change_access_port_vlans(old_vlan, new_vlan, ssh_device):
     # Create instance variables and objects.
     logger = logging.getLogger(__name__)
+    command_text = "end\nconf t\n"
 
     # Loop through interfaces and get a list of interfaces with interfaces on VLAN1.
     interface_vlan_change_list = []
@@ -32,13 +33,12 @@ def change_access_port_vlans(old_vlan, new_vlan, ssh_device):
         # Catch key errors for malformed interface output.
         try:
             # Check the interface vlan.
-            if int(interface["switchport access vlan"]) == int(old_vlan) and interface["vlan_status"] == old_vlan and not interface["switchport mode trunk"] and ("Fa" not in interface["name"] and "Ap" not in interface["name"]) and "trunk" not in interface["vlan_status"]:
+            if int(interface["switchport access vlan"]) == int(old_vlan) and interface["vlan_status"] == old_vlan and not interface["switchport mode trunk"] and ("Ap" not in interface["name"]) and "trunk" not in interface["vlan_status"]:
                 interface_vlan_change_list.append(interface["name"])
         except KeyError as error:
             logger.error(f"KeyError ({error}): An interface output for {ssh_device['hostname']} was not received properly, skipping...")
 
     # Check that we have at least 1 interface to change.
-    vlan_command_text = ""
     if len(interface_vlan_change_list) > 0:
         # Convert the list into more compact ranges, CiscoIOS can only handle 5-8 ranges.
         interface_port_types = {}
@@ -51,7 +51,6 @@ def change_access_port_vlans(old_vlan, new_vlan, ssh_device):
                 interface_port_types[key].append(re.split("/|Po", interface)[-1])
 
         # Group the interfaces together to be more efficient.
-        vlan_command_text = "end\nconf t\n"
         interface_ranges = ""
         range_counter = 0
         for key in interface_port_types.keys():
@@ -67,8 +66,8 @@ def change_access_port_vlans(old_vlan, new_vlan, ssh_device):
                     # Remove last comma and space from interface range text.
                     interface_ranges = interface_ranges[:-2]
                     # Build commands list for vlan change.
-                    vlan_command_text += f"int range {interface_ranges}\n"
-                    # vlan_command_text += f"sw acc vlan {new_vlan}\n"
+                    command_text += f"int range {interface_ranges}\n"
+                    command_text += f"sw acc vlan {new_vlan}\n"
                     # Clear interface_range text and reset counter.
                     interface_ranges = ""
                     range_counter = 0
@@ -88,9 +87,179 @@ def change_access_port_vlans(old_vlan, new_vlan, ssh_device):
         # Remove last comma and space from interface range text.
         interface_ranges = interface_ranges[:-2]
         # Build commands list for vlan change.
-        vlan_command_text += f"int range {interface_ranges}\n"
-        # vlan_command_text += f"sw acc vlan {new_vlan}\n"
+        command_text += f"int range {interface_ranges}\n"
+        command_text += f"sw acc vlan {new_vlan}\n"
         # Add end to exit global config mode.
-        vlan_command_text += "end\n"
+        command_text += "end\n"
 
-        return vlan_command_text
+    return command_text
+
+def setup_dhcp_snooping_on_trunks(ssh_device, snoop_vlans, disable_option_82=True):
+    # Create instance variables and objects.
+    logger = logging.getLogger(__name__)
+    command_text = ""
+
+    # Loop through interfaces and get a list of interfaces with interfaces on VLAN1.
+    interface_change_list = []
+    for interface in ssh_device["interfaces"]:
+        # Catch key errors for malformed interface output.
+        try:
+            # Check the interface vlan.
+            if interface["vlan_status"] == "trunk" and ("Ap" not in interface["name"]):
+                interface_change_list.append(interface["name"])
+        except KeyError as error:
+            logger.error(f"KeyError ({error}): An interface output for {ssh_device['hostname']} was not received properly, skipping...")
+
+    # Check that we have at least 1 interface to change.
+    if len(interface_change_list) > 0:
+        # Convert the list into more compact ranges, CiscoIOS can only handle 5-8 ranges.
+        interface_port_types = {}
+        for interface in interface_change_list:
+            # Cutoff first two or three letters of interface and add key to dictionary if it doesn't exist. If it doesn exist, then append it to the list in the dictionary.
+            key = re.split("/", interface[::-1], 1)[-1][::-1]
+            if key not in interface_port_types.keys():
+                interface_port_types[key] = [re.split("/|Po", interface)[-1]]
+            else:
+                interface_port_types[key].append(re.split("/|Po", interface)[-1])
+
+        # Check if snoop_vlans contains something.
+        if len(snoop_vlans) > 0:
+            # Build global DHCP snooping commands.
+            command_text += f"end\nconf t\n"
+            
+            # Group the interfaces together to be more efficient.
+            interface_ranges = ""
+            range_counter = 0
+            for key in interface_port_types.keys():
+                # Get the interface list.
+                interface_numbers = interface_port_types[key]
+                interface_numbers = list(map(int, interface_numbers))
+                # Group numbers.
+                interface_numbers = list(find_ranges(interface_numbers))
+                # Parse command text.
+                for range in interface_numbers:
+                    # Check if we have hit five ranges.
+                    if range_counter >= 5:
+                        # Remove last comma and space from interface range text.
+                        interface_ranges = interface_ranges[:-2]
+                        # Build commands list for vlan change.
+                        command_text += f"int range {interface_ranges}\n"
+                        command_text += f"ip dhcp snooping trust\n"
+
+                        # Clear interface_range text and reset counter.
+                        interface_ranges = ""
+                        range_counter = 0
+
+                    # Lookout for port channel interfaces.
+                    if "Po" in key:
+                        interface_ranges += f"{key}, "
+                    # Check if the current range is a tuple or a single integer.
+                    elif isinstance(range, tuple):
+                        interface_ranges += f"{key}/{range[0]}-{range[1]}, "
+                    else:
+                        interface_ranges += f"{key}/{range}, "
+                    
+                    # Increment counter.
+                    range_counter += 1
+            
+            # Remove last comma and space from interface range text.
+            interface_ranges = interface_ranges[:-2]
+            # Build commands list for vlan change.
+            command_text += f"int range {interface_ranges}\n"
+            command_text += "ip dhcp snooping trust\n"
+            command_text += "end\nconf t\n"
+
+            # Disable option82 insertion if enabled.
+            if disable_option_82:
+                command_text += "no ip dhcp snooping information option\n"
+            # Turn on snooping for vlans.
+            command_text += f"ip dhcp snooping\n"
+            command_text += f"ip dhcp snooping vlan {snoop_vlans}\n"
+
+            # Add end to exit global config mode.
+            command_text += "end\n"
+
+    return command_text
+
+def setup_dynamic_arp_inspection_on_trunks(ssh_device, dai_vlans):
+    # Create instance variables and objects.
+    logger = logging.getLogger(__name__)
+    command_text = ""
+
+    # Loop through interfaces and get a list of interfaces with interfaces on VLAN1.
+    interface_change_list = []
+    for interface in ssh_device["interfaces"]:
+        # Catch key errors for malformed interface output.
+        try:
+            # Check the interface vlan.
+            if interface["vlan_status"] == "trunk" and ("Ap" not in interface["name"]):
+                interface_change_list.append(interface["name"])
+        except KeyError as error:
+            logger.error(f"KeyError ({error}): An interface output for {ssh_device['hostname']} was not received properly, skipping...")
+
+    # Check that we have at least 1 interface to change.
+    if len(interface_change_list) > 0:
+        # Convert the list into more compact ranges, CiscoIOS can only handle 5-8 ranges.
+        interface_port_types = {}
+        for interface in interface_change_list:
+            # Cutoff first two or three letters of interface and add key to dictionary if it doesn't exist. If it doesn exist, then append it to the list in the dictionary.
+            key = re.split("/", interface[::-1], 1)[-1][::-1]
+            if key not in interface_port_types.keys():
+                interface_port_types[key] = [re.split("/|Po", interface)[-1]]
+            else:
+                interface_port_types[key].append(re.split("/|Po", interface)[-1])
+
+        # Check if the dai_vlans list contains something.
+        if len(dai_vlans) > 0:
+            # Build global ARP inspection commands.
+            command_text += f"end\nconf t\n"
+            
+            # Group the interfaces together to be more efficient.
+            interface_ranges = ""
+            range_counter = 0
+            for key in interface_port_types.keys():
+                # Get the interface list.
+                interface_numbers = interface_port_types[key]
+                interface_numbers = list(map(int, interface_numbers))
+                # Group numbers.
+                interface_numbers = list(find_ranges(interface_numbers))
+                # Parse command text.
+                for range in interface_numbers:
+                    # Check if we have hit five ranges.
+                    if range_counter >= 5:
+                        # Remove last comma and space from interface range text.
+                        interface_ranges = interface_ranges[:-2]
+                        # Build commands list for vlan change.
+                        command_text += f"int range {interface_ranges}\n"
+                        command_text += f"ip arp inspection trust\n"
+                        
+                        # Clear interface_range text and reset counter.
+                        interface_ranges = ""
+                        range_counter = 0
+
+                    # Lookout for port channel interfaces.
+                    if "Po" in key:
+                        interface_ranges += f"{key}, "
+                    # Check if the current range is a tuple or a single integer.
+                    elif isinstance(range, tuple):
+                        interface_ranges += f"{key}/{range[0]}-{range[1]}, "
+                    else:
+                        interface_ranges += f"{key}/{range}, "
+                    
+                    # Increment counter.
+                    range_counter += 1
+            
+            # Remove last comma and space from interface range text.
+            interface_ranges = interface_ranges[:-2]
+            # Build commands list for vlan change.
+            command_text += f"int range {interface_ranges}\n"
+            command_text += "ip arp inspection trust\n"
+            command_text += "end\nconf t\n"
+
+            # Enable ARP inspection for vlans.
+            command_text += f"ip arp inspection vlan {dai_vlans}\n"
+
+            # Add end to exit global config mode.
+            command_text += "end\n"
+
+    return command_text

--- a/utils/open_connection.py
+++ b/utils/open_connection.py
@@ -343,7 +343,7 @@ def get_config_info(connection) -> netmiko.ssh_dispatcher:
                     # Split line by spaces.
                     line = re.split(" +", line)
                     # Check if the second to last element contains just CSR4. If so, then join the last two elements together.
-                    if line[-2] == "CSR4":
+                    if "SR4" in line[-2]:
                     # Get the last two elements and add them together.
                         new_type = f"{line.pop(-4)} {line.pop(-3)} {line.pop(-2)} {line.pop(-1)}"
                         # Reappend to line.


### PR DESCRIPTION
- NetCommander can now procedurally enable DHCP snooping on user selected switches and VLANs, all ACTIVE trunk ports are trusted. (There is also a checkbox to disable option 82 insertion)
- NetCommander can now procedurally enable dynamic ARP inspection on user selected switches and VLANs, all ACTIVE trunk ports are trusted.